### PR TITLE
return undefined if IE 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,10 @@ var el = document.createElement('p');
 var style;
 
 for (var i = 0; i < styles.length; i++) {
-  style = styles[i];
-  if (null != el.style[style]) {
-    module.exports = style;
+  if (null != el.style[styles[i]]) {
+    style = styles[i];
     break;
   }
 }
+
+module.exports = style;


### PR DESCRIPTION
In IE 8, the previous version doesn't actually export undefined or null, which, in turn, screwed up `component/translate`. This edit still defines an export, even if the style attribute is never defined. 
